### PR TITLE
Cache template file paths during runtime

### DIFF
--- a/src/Dust/Dust.php
+++ b/src/Dust/Dust.php
@@ -24,6 +24,12 @@ namespace Dust
         public $templates = [];
 
         /**
+         * Stores found template paths for faster template loading.
+         * @var array
+         */
+        protected static $dustFileCache = [];
+
+        /**
          * @var array
          */
         public $filters = [];
@@ -86,7 +92,7 @@ namespace Dust
                 "if"          => new Helper\IfHelper(),
                 "lt"          => new Helper\Lt(),
                 "lte"         => new Helper\Lte(),
-                "ne"         => new Helper\Ne(),
+                "ne"          => new Helper\Ne(),
                 "gt"          => new Helper\Gt(),
                 "gte"         => new Helper\Gte(),
                 "default"     => new Helper\DefaultHelper(),
@@ -136,10 +142,16 @@ namespace Dust
          * @return null|string
          */
         public function resolveAbsoluteDustFilePath($path, $basePath = NULL) {
+
             //add extension if necessary
             if(substr_compare($path, self::FILE_EXTENSION, -5, 5) !== 0)
             {
                 $path .= self::FILE_EXTENSION;
+            }
+
+            // Get from cache if the file is already found.
+            if ( isset( static::$dustFileCache[ $path ] ) ) {
+                return static::$dustFileCache[ $path ];
             }
 
             //try the current path
@@ -154,10 +166,17 @@ namespace Dust
             foreach ( $this->includedDirectories as $directory ) {
                 foreach ( new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $directory, \RecursiveDirectoryIterator::SKIP_DOTS ) ) as $file ) {
                     if ( substr_compare($file, "/".$path, strlen($file)-strlen("/".$path), strlen("/".$path)) === 0 ) {
+
+                        // Cache the found file.
+                        static::$dustFileCache[ $path ] = (string) $file;
+
                         return (string)$file;
                     }
                 }
             }
+
+            // Cache the not found result to prevent subsequent searches.
+            static::$dustFileCache[ $path ] = NULL;
 
             return NULL;
         }


### PR DESCRIPTION
Cache dust template file paths during runtime to prevent multiple recursive directory searches for same template requests.